### PR TITLE
Lambda VPC config

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -27,6 +27,11 @@ resource "aws_lambda_function" "notify_slack" {
       ICON       = var.icon
     }
   }
+
+  vpc_config {
+    subnet_ids         = var.subnet_ids
+    security_group_ids = var.security_group_ids
+  }
 }
 
 resource "aws_lambda_permission" "allow_sns" {

--- a/variables.tf
+++ b/variables.tf
@@ -60,3 +60,15 @@ variable "icon" {
   type        = string
   default     = ":loudspeaker:"
 }
+
+variable "subnet_ids" {
+  description = "VPC subnets for Lambda"
+  type        = list(string)
+  default     = []
+}
+
+variable "security_group_ids" {
+  description = "SG IDs for Lambda, should at least allow all outbound"
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
adds support for VPC subnet configuration required by AWS config rule **lambda-inside-vpc**:
 https://docs.aws.amazon.com/config/latest/developerguide/lambda-inside-vpc.html