### PR TITLE
Rename parameter number to numeric

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@ resource "random_string" "lambda_postfix_generator" {
   length  = 16
   upper   = true
   lower   = true
-  number  = true
+  numeric = true
   special = false
 }
 


### PR DESCRIPTION
* Fixes Warning: Argument is deprecated. Use numeric instead.